### PR TITLE
Added uciok to end of response to 'uci'.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ fn main() {
                         "uci" => {
                             println!("id name Crabfish {}", env!("CARGO_PKG_VERSION"));
                             println!("id author Jonathan Li");
+                            println!("uciok");
                         }
                         "isready" => {
                             println!("readyok");


### PR DESCRIPTION
The engine must send `uciok` after all the `id` and `option` commands have been sent to inform the interface it is running in it has sent everything to ensure the interface does not forcibly terminate it.